### PR TITLE
Prevent Heroku from Idling

### DIFF
--- a/app.py
+++ b/app.py
@@ -20,17 +20,18 @@ from linebot.models import (
 )
 
 # Prevent heroku from idling
-def keepAlive(second):
+def keepAlive():
     while 1:
         with urllib.request.urlopen(os.getenv('HOST_URL', None)) as response:
             html = response.read()
-            sleep(second)
+            print('PING')
+            sleep(1)
 
 # Create application server
 app = Flask(__name__)
 
 # Start thread to ping server
-thread = threading.Thread(target=keepAlive, args=[60])
+thread = threading.Thread(target=keepAlive)
 thread.start()
 
 # Environment variabel

--- a/app.py
+++ b/app.py
@@ -1,6 +1,10 @@
 from __future__ import unicode_literals #backward compatibility for python2
 # Module for os or system related stuff
-import os, sys
+import os, sys, threading
+# Module for HTTP GET
+import urllib.request
+# Module for delay
+from time import sleep
 # Module for building server
 from flask import Flask, request, abort
 from router.router import *
@@ -14,8 +18,20 @@ from linebot.exceptions import (
 from linebot.models import (
     MessageEvent, TextMessage, TextSendMessage,
 )
+
+# Prevent heroku from idling
+def keepAlive(second):
+    while 1:
+        with urllib.request.urlopen(os.getenv('HOST_URL', None)) as response:
+            html = response.read()
+            sleep(second)
+
 # Create application server
 app = Flask(__name__)
+
+# Start thread to ping server
+thread = threading.Thread(target=keepAlive, args=[60])
+thread.start()
 
 # Environment variabel
 channel_secret = os.getenv('LINE_CHANNEL_SECRET', None) 

--- a/app.py
+++ b/app.py
@@ -24,8 +24,7 @@ def keepAlive():
     while 1:
         with urllib.request.urlopen(os.getenv('HOST_URL', None)) as response:
             html = response.read()
-            print('PING')
-            sleep(1)
+            sleep(120)
 
 # Create application server
 app = Flask(__name__)


### PR DESCRIPTION
I've founded a critical bug when I tried reminder features. So this morning I set a reminder on 12PM using Gabot. I left my phone for a while then I got back to it at 1PM, open my LINE App to see whether there was any reminder. Nothing. Gabot didn't do its job.

So I look out to the heroku logs and found out that the server status is now "idling". I think this is the problem. It killed all the worker including the reminder feature so Gabot couldn't do its job.

I've made function called `keepAlive` that ping the server itself every **2 minutes** so the server won't go idling. Please review