### PR TITLE
Add exception handler, change route

### DIFF
--- a/app.py
+++ b/app.py
@@ -10,6 +10,8 @@ from linebot.models import (
     MessageEvent, TextMessage, TextSendMessage,
 )
 
+import os
+
 app = Flask(__name__)
 
 channel_secret = os.getenv('LINE_CHANNEL_SECRET', None) 

--- a/app.py
+++ b/app.py
@@ -1,7 +1,16 @@
+from __future__ import unicode_literals #backward compatibility for python2
+# Module for os or system related stuff
+import os, sys, threading
+# Module for HTTP GET
+import urllib.request
+# Module for delay
+from time import sleep
+# Module for building server
 from flask import Flask, request, abort
-
+from router.router import *
+# Module for Line SDK
 from linebot import (
-    LineBotApi, WebhookHandler
+    LineBotApi, WebhookParser
 )
 from linebot.exceptions import (
     InvalidSignatureError
@@ -10,42 +19,39 @@ from linebot.models import (
     MessageEvent, TextMessage, TextSendMessage,
 )
 
-import os
+# Prevent heroku from idling
+def keepAlive():
+    while 1:
+        with urllib.request.urlopen(os.getenv('HOST_URL', None)) as response:
+            html = response.read()
+            sleep(120)
 
+# Create application server
 app = Flask(__name__)
 
+# Start thread to ping server
+thread = threading.Thread(target=keepAlive)
+thread.start()
+
+# Environment variabel
 channel_secret = os.getenv('LINE_CHANNEL_SECRET', None) 
 channel_access_token = os.getenv('LINE_CHANNEL_ACCESS_TOKEN', None)
 
+# Handler
+if channel_secret is None:
+    print('Specify LINE_CHANNEL_SECRET as environment variable.')
+    sys.exit(1)
+if channel_access_token is None:
+    print('Specify LINE_CHANNEL_ACCESS_TOKEN as environment variable.')
+    sys.exit(1)
+
+# Init API and Webhook
 line_bot_api = LineBotApi(channel_access_token)
-handler = WebhookHandler(channel_secret)
+parser = WebhookParser(channel_secret)
 
+# Router
+router(app, parser, line_bot_api)
 
-@app.route("/callback", methods=['POST'])
-def callback():
-    # get X-Line-Signature header value
-    signature = request.headers['X-Line-Signature']
-
-    # get request body as text
-    body = request.get_data(as_text=True)
-    app.logger.info("Request body: " + body)
-
-    # handle webhook body
-    try:
-        handler.handle(body, signature)
-    except InvalidSignatureError:
-        print("Invalid signature. Please check your channel access token/channel secret.")
-        abort(400)
-
-    return 'OK'
-
-
-@handler.add(MessageEvent, message=TextMessage)
-def handle_message(event):
-    line_bot_api.reply_message(
-        event.reply_token,
-        TextSendMessage(text=event.message.text))
-
-
+# Run server
 if __name__ == "__main__":
-    app.run()
+    app.run(debug=True, port=os.getenv('PORT', None))

--- a/app.py
+++ b/app.py
@@ -30,8 +30,8 @@ def keepAlive():
 app = Flask(__name__)
 
 # Start thread to ping server
-thread = threading.Thread(target=keepAlive)
-thread.start()
+# thread = threading.Thread(target=keepAlive)
+# thread.start()
 
 # Environment variabel
 channel_secret = os.getenv('LINE_CHANNEL_SECRET', None) 

--- a/res/text/reminder.py
+++ b/res/text/reminder.py
@@ -172,7 +172,11 @@ class Reminder():
         # Iterate data
         for i in data:
             # Get user data
-            user = self.line_bot_api.get_profile(i['userId'])
+            try:
+                user = self.line_bot_api.get_profile(i['userId'])
+            except Exception as e:
+                print(e)
+                continue
             # Show username
             str += f"From {user.display_name}\n"
             # Change datetime format

--- a/res/text/schedule.py
+++ b/res/text/schedule.py
@@ -15,8 +15,12 @@ class Schedule():
     def __init__(self, event, line_bot_api):
         self.event = event
         # Get user data
-        self.user = line_bot_api.get_profile(event.source.user_id)
-        self.line_bot_api = line_bot_api
+        try:
+            self.user = line_bot_api.get_profile(event.source.user_id)
+            self.line_bot_api = line_bot_api
+        except Exception as e:
+            print(e)
+            return
         # Set timezone
         region = pytz.timezone("Asia/Jakarta")
         # Get current time based on timezone

--- a/router/router.py
+++ b/router/router.py
@@ -6,7 +6,7 @@ def router(app, parser, line_bot_api):
     def index():
         return controllers.index()
 
-    @app.route("/callback", methods=['POST'])
+    @app.route("/", methods=['POST'])
     def callback():
         return controllers.handler(app,parser,line_bot_api)
 


### PR DESCRIPTION
There is some bug I found when Gabot tried to post a request to '/' route.
At first, it was designed to do HTTP POST on '/callback' route, but then Gabot starting to do HTTP POST on '/' route. So I change the route to '/'

The second issue is when there is an error occurs, there is no exception handler so Gabot takes time to recover after dealing with unhandled exception.